### PR TITLE
charm-dev updates

### DIFF
--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -32,6 +32,7 @@ instances:
         - zsh
         - fzf
         - tox
+        - gnome-keyring
 
         snap:
           commands:

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -108,4 +108,8 @@ instances:
           sudo -u ubuntu juju bootstrap --no-gui microk8s charm-dev
           sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome
 
+          # dump config (this is needed for utils such as k9s or kdash)
+          sudo -u ubuntu mkdir -p /home/ubuntu/.kube
+          microk8s config > /home/ubuntu/.kube/config
+
         final_message: "The system is finally up, after $UPTIME seconds"


### PR DESCRIPTION
- Enable cluster access by dumping microk8s config.
- Install gnome-keyring, which is [needed](https://github.com/canonical/charmcraft/issues/719#issuecomment-1087643162) by charmcraft