### PR TITLE
[ci] add integration tests for blueprints

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,12 @@
 name: Integration
 
 on:
-  push:
+  workflow_dispatch:
+    inputs:
+      blueprint:
+        description: Blueprint to test
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   GetMatrix:
@@ -13,6 +18,11 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    - name: Install yq
+      uses: chrisdickinson/setup-yq@latest
 
     - name: Determine job matrix
       id: set-matrix
@@ -21,11 +31,31 @@ jobs:
 
         MATRIX=""
 
-        # If on push, test a predefined set of blueprints
-        if [ "${{ github.event_name }}" == "push" ]; then
+        if ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.blueprint != '' }}; then
+          # If no blueprint provided, test a predefined set
           MATRIX+='{"os": "Linux", "vm": "linux", "blueprint": "minikube"}'
           MATRIX+='{"os": "macOS", "vm": "macos-12", "arch": "x86_64", "blueprint": "docker" }'
           MATRIX+='{"os": "macOS", "arch": "arm64", "blueprint": "charm-dev" }'
+        else
+          if ${{ github.event_name == 'workflow_dispatch' }}; then
+            # On workflow dispatch, test the provided blueprint
+            FILES=$( ls v1/${{ github.event.inputs.blueprint }}.yaml )
+          else
+            # On pull requests, find modified blueprints
+            FILES=$( ls $( git diff --name-only HEAD^1 | grep 'v1/.*.yaml' ) )
+          fi
+
+          for file in ${FILES}; do
+            BLUEPRINT=$( basename -- "${file%.*}" )
+            if [ -z "$( yq read ${file} 'runs-on' )" -o -n "$( yq read ${file} 'runs-on.(.==x86_64)' )" ]; then
+              MATRIX+='{"os": "Linux", "vm": "linux", "blueprint": "'${BLUEPRINT}'"}'
+              MATRIX+='{"os": "macOS", "vm": "macos-12", "arch": "x86_64", "blueprint": "'${BLUEPRINT}'" }'
+            fi
+
+            if [ -z "$( yq read ${file} 'runs-on' )" -o -n "$( yq read ${file} 'runs-on.(.==arm64)' )" ]; then
+              MATRIX+='{"os": "macOS", "arch": "arm64", "blueprint": "'${BLUEPRINT}'" }'
+            fi
+          done
         fi
 
         echo "${MATRIX}" | jq -cs '{"include": . }' | awk '{ print "::set-output name=matrix::" $0 }'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,47 @@ jobs:
       TESTFLINGER_FILE: testflinger-${{ matrix.os }}-${{ matrix.driver }}.yaml
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Install yq
+      uses: chrisdickinson/setup-yq@latest
+
+    - name: Determine blueprint parameters
+      id: blueprint-params
+      run: |
+        # Give extra memory for the OS
+        MEM="$( yq read --defaultValue null 'v1/${{ matrix.blueprint }}.yaml' 'instances.${{ matrix.blueprint }}.limits.min-mem' )"
+        AMOUNT="$( echo ${MEM} | sed 's/[[:alpha:]]//g' )"
+        case "${MEM}" in
+          null)
+            MEM=2048
+            ;;
+          *G|*GB|*GiB)
+            MEM=$(( ${AMOUNT} * 1024 + 1536 ))
+            ;;
+          *M|*MB|*MiB)
+            MEM=$(( ${AMOUNT} + 1536 ))
+            ;;
+          *)
+            echo "::error ::Failed to interpret \"min-mem\" limit: \"$MEM\""
+            exit 1
+            ;;
+        esac
+        echo "::set-output name=memsize::${MEM}"
+
+        # Double the declared timeout
+        TIMEOUT="$( yq read --defaultValue null 'v1/${{ matrix.blueprint }}.yaml' 'instances.${{ matrix.blueprint }}.timeout' )"
+        case "${TIMEOUT}" in
+          null)
+            TIMEOUT=1200
+            ;;
+          *)
+            TIMEOUT=$(( ${TIMEOUT} * 2 ))
+            ;;
+        esac
+        echo "::set-output name=timeout::${TIMEOUT}"
+
     - name: Write the testflinger job
       uses: DamianReeves/write-file-action@v1.0
       with:
@@ -58,7 +99,7 @@ jobs:
             snapshot: Blueprints
             ${{ matrix.os == 'Linux' && 'image_url: http://cloud-images.ubuntu.com/releases/impish/release/ubuntu-21.10-server-cloudimg-amd64.img' || '' }}
             vmx_config:
-              memsize: 2048
+              memsize: ${{ steps.blueprint-params.outputs.memsize }}
               vhv.enable: true
               vpmc.enable: true
 
@@ -147,7 +188,7 @@ jobs:
               # Give multipassd time to settle (canonical/multipass#1995)
               _retry_grep 12 5 "^${{ matrix.blueprint }}\W" _run $MP find
 
-              _run $MP launch ${{ matrix.blueprint }} --timeout 1200
+              _run $MP launch ${{ matrix.blueprint }} --timeout ${{ steps.blueprint-params.outputs.timeout }}
 
               _run $MP list
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,175 @@
+name: Integration
+
+on:
+  push:
+
+jobs:
+  GetMatrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Determine job matrix
+      id: set-matrix
+      run: |
+        set -euo pipefail
+
+        MATRIX=""
+
+        # If on push, test a predefined set of blueprints
+        if [ "${{ github.event_name }}" == "push" ]; then
+          MATRIX+='{"os": "Linux", "vm": "linux", "blueprint": "minikube"}'
+          MATRIX+='{"os": "macOS", "vm": "macos-12", "arch": "x86_64", "blueprint": "docker" }'
+          MATRIX+='{"os": "macOS", "arch": "arm64", "blueprint": "charm-dev" }'
+        fi
+
+        echo "${MATRIX}" | jq -cs '{"include": . }' | awk '{ print "::set-output name=matrix::" $0 }'
+
+  CI:
+    needs: GetMatrix
+
+    runs-on: testflinger
+
+    timeout-minutes: 60
+
+    strategy:
+      matrix: ${{ fromJSON(needs.GetMatrix.outputs.matrix) }}
+      fail-fast: false
+
+    env:
+      TESTFLINGER_FILE: testflinger-${{ matrix.os }}-${{ matrix.driver }}.yaml
+
+    steps:
+    - name: Write the testflinger job
+      uses: DamianReeves/write-file-action@v1.0
+      with:
+        path: ${{ env.TESTFLINGER_FILE }}
+        write-mode: overwrite
+        contents: |
+          job_queue: ${{ matrix.os == 'macOS' && matrix.arch == 'arm64' && 'macos-arm' || 'vmware-fusion' }}
+          output_timeout: 2400
+          provision_data:
+            ${{ matrix.vm && format('vmx: /Users/michal/Virtual Machines.localized/{0}.vmwarevm/{0}.vmx', matrix.vm) || '' }}
+            snapshot: Blueprints
+            ${{ matrix.os == 'Linux' && 'image_url: http://cloud-images.ubuntu.com/releases/impish/release/ubuntu-21.10-server-cloudimg-amd64.img' || '' }}
+            vmx_config:
+              memsize: 2048
+              vhv.enable: true
+              vpmc.enable: true
+
+          test_data:
+            test_cmds: |
+              set -xeuo pipefail
+
+              MP=multipass
+              [ '${{ matrix.os }}' == 'macOS' ] && MP=/usr/local/bin/multipass
+
+              function _run() {{
+                ssh ${{ '${{SSH_OPTS}} "${{DEVICE_USER}}@${{DEVICE_IP}}" -- "${{@}}"' }}
+              }}
+
+              # Retry $1 times, with $2 seconds in between tries
+              function _retry() {{
+                  tries=$1
+                  interval=$2
+                  shift 2
+                  for try in $( seq $tries ); do
+                      RC=0
+                      ${{ '"${{@}}"' }} || RC=$?
+                      [ $RC -eq 0 -o $try -eq $tries ] && return $RC
+                      sleep $interval;
+                  done
+              }}
+
+              # Retry $1 times, with $2 seconds in between tries, until $3 greps
+              function _retry_grep() {{
+                  tries=$1
+                  interval=$2
+                  pattern=$3
+                  shift 3
+                  for try in $( seq $tries ); do
+                      RC=0
+                      ${{ '"${{@}}"' }} | grep --quiet -e "$pattern" || RC=$?
+                      [ $RC -eq 0 -o $try -eq $tries ] && return $RC
+                      sleep $interval;
+                  done
+              }}
+
+              # Log journal entries on bad exit
+              function _exit() {{
+                RC=$?
+                if [ '${{ matrix.os }}' == 'Linux' ]; then
+                  [ $RC -eq 0 ] || _run sudo journalctl -u snap.multipass*
+                elif [ '${{ matrix.os }}' == 'macOS' ]; then
+                  [ $RC -eq 0 ] || _run sudo cat /Library/Logs/Multipass/multipassd.log
+                  # Authenticate the root user
+                  _run $MP set local.passphrase=foobar || true
+                  _run sudo $MP authenticate foobar || true
+                  ( echo y; echo y ) | _run sudo PATH=/bin:/usr/local/bin /bin/sh "/Library/Application\\ Support/com.canonical.multipass/uninstall.sh" || true
+                  _run sudo rm -rf /Library/Logs/Multipass
+                fi
+              }}
+              trap _exit EXIT
+
+              function _install() {{
+                PACKAGE="$1"
+
+                if [ '${{ matrix.os }}' == 'Linux' ]; then
+                  # Give snapd time to settle
+                  _retry 5 30 _run sudo sh -c "snap\ list\ multipass && sudo snap refresh multipass --channel ${PACKAGE} || sudo snap install multipass --channel ${PACKAGE}"
+
+                elif [ '${{ matrix.os }}' == 'macOS' ]; then
+                  ( echo y; echo y ) | _run sudo PATH=/bin:/usr/local/bin /bin/sh "/Library/Application\\ Support/com.canonical.multipass/uninstall.sh" || true
+                  _run curl --location --output multipass.pkg "${PACKAGE}"
+                  _run sudo installer -dumplog -target / -pkg multipass.pkg
+                fi
+              }}
+
+              if [ '${{ matrix.os }}' == 'Linux' ]; then
+                OVERRIDE_CONF="/etc/systemd/system/snap.multipass.multipassd.service.d/override.conf"
+                _run sudo mkdir -p $( dirname ${OVERRIDE_CONF} )
+                _run sudo tee ${OVERRIDE_CONF} <<- EOF
+                  [Service]
+                  ExecStart=
+                  ExecStart=/usr/bin/snap run multipass.multipassd --verbosity trace
+              EOF
+                _install beta
+
+              elif [ '${{ matrix.os }}' == 'macOS' ]; then
+                _install https://github.com/canonical/multipass/releases/download/v1.9.0-rc/multipass-1.9.0-rc.557+gc2561306.mac-Darwin.pkg
+              fi
+
+              # Give multipassd time to settle (canonical/multipass#1995)
+              _retry_grep 12 5 "^${{ matrix.blueprint }}\W" _run $MP find
+
+              _run $MP launch ${{ matrix.blueprint }} --timeout 1200
+
+              _run $MP list
+
+              _run $MP exec ${{ matrix.blueprint }} -- uname -a
+
+    - name: Run the job
+      id: run
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 60
+        max_attempts: 2
+        command: |
+          JOB_ID=$( testflinger-cli submit --quiet ${TESTFLINGER_FILE} )
+          echo "${JOB_ID}" > testflinger_job
+
+          testflinger-cli poll "${JOB_ID}"
+          [ "$( testflinger-cli results ${JOB_ID} | jq -r .test_status )" -eq 0 ]
+
+        on_retry_command: |
+          testflinger-cli cancel "$( cat testflinger_job )"
+
+    - name: Cancel the job
+      if: ${{ cancelled() }}
+      run: |
+        if [ -f testflinger_job ]; then testflinger-cli cancel "$( cat testflinger_job )"; fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,8 +48,16 @@ jobs:
           for file in ${FILES}; do
             BLUEPRINT=$( basename -- "${file%.*}" )
             if [ -z "$( yq read ${file} 'runs-on' )" -o -n "$( yq read ${file} 'runs-on.(.==x86_64)' )" ]; then
-              MATRIX+='{"os": "Linux", "vm": "linux", "blueprint": "'${BLUEPRINT}'"}'
-              MATRIX+='{"os": "macOS", "vm": "macos-12", "arch": "x86_64", "blueprint": "'${BLUEPRINT}'" }'
+
+              case ${BLUEPRINT} in
+                charm-dev)
+                  # the `charm-dev` blueprint is too heavy for nested runs
+                  ;;
+                *)
+                  MATRIX+='{"os": "Linux", "vm": "linux", "blueprint": "'${BLUEPRINT}'"}'
+                  MATRIX+='{"os": "macOS", "vm": "macos-12", "arch": "x86_64", "blueprint": "'${BLUEPRINT}'" }'
+                ;;
+              esac
             fi
 
             if [ -z "$( yq read ${file} 'runs-on' )" -o -n "$( yq read ${file} 'runs-on.(.==arm64)' )" ]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -131,7 +131,7 @@ jobs:
         write-mode: overwrite
         contents: |
           job_queue: ${{ matrix.os == 'macOS' && matrix.arch == 'arm64' && 'macos-arm' || 'vmware-fusion' }}
-          output_timeout: 2400
+          output_timeout: ${{ steps.blueprint-params.outputs.timeout }}
           provision_data:
             ${{ matrix.vm && format('vmx: /Users/michal/Virtual Machines.localized/{0}.vmwarevm/{0}.vmx', matrix.vm) || '' }}
             snapshot: Blueprints

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -224,6 +224,10 @@ jobs:
               elif [ '${{ matrix.os }}' == 'macOS' ]; then
                 PLIST_FILE="/Library/LaunchDaemons/com.canonical.multipassd.plist"
                 _install https://github.com/canonical/multipass/releases/download/v1.9.0-rc/multipass-1.9.0-rc.557+gc2561306.mac-Darwin.pkg
+
+                # force use of the qemu driver
+                _retry 5 30 _run $MP set local.driver=qemu
+
                 _run "sudo /usr/libexec/PlistBuddy -c \
                   'Add :EnvironmentVariables:MULTIPASS_BLUEPRINTS_URL string ${MULTIPASS_BLUEPRINTS_URL}' \
                   ${PLIST_FILE}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,7 +73,7 @@ jobs:
 
     runs-on: testflinger
 
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     strategy:
       matrix: ${{ fromJSON(needs.GetMatrix.outputs.matrix) }}
@@ -256,7 +256,7 @@ jobs:
       id: run
       uses: nick-fields/retry@v2
       with:
-        timeout_minutes: 60
+        timeout_minutes: 90
         max_attempts: 2
         command: |
           JOB_ID=$( testflinger-cli submit --quiet ${TESTFLINGER_FILE} )

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -224,7 +224,11 @@ jobs:
               fi
 
               # Give multipassd time to settle (canonical/multipass#1995)
-              _retry_grep 12 5 "^${{ matrix.blueprint }}\W" _run $MP find
+              if ! _retry_grep 12 5 "^${{ matrix.blueprint }}\W" _run $MP find; then
+                echo "::error Failed to find blueprint: ${{ matrix.blueprint }}"
+                _run $MP find
+                exit 1
+              fi
 
               _run $MP launch ${{ matrix.blueprint }} --timeout ${{ steps.blueprint-params.outputs.timeout }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -192,7 +192,15 @@ jobs:
 
               _run $MP list
 
-              _run $MP exec ${{ matrix.blueprint }} -- uname -a
+    - name: Add the health check script
+      run: |
+        # This is meh, but found no better way to indent properly into the yaml
+        cat <<EOF | awk '{ print "    " $0 }' >> ${TESTFLINGER_FILE}
+        # This line needed for YAML formatting
+        _run \$MP exec ${{ matrix.blueprint }} -- sh << EOSH
+        $( yq read --defaultValue 'uname -a' 'v1/${{ matrix.blueprint  }}.yaml' 'health-check' )
+        EOSH
+        EOF
 
     - name: Run the job
       id: run

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -209,6 +209,7 @@ jobs:
                 fi
               }}
 
+              MULTIPASS_BLUEPRINTS_URL="${{ format('{0}/{1}/archive/{2}.zip', github.server_url, github.repository, github.ref) }}"
               if [ '${{ matrix.os }}' == 'Linux' ]; then
                 OVERRIDE_CONF="/etc/systemd/system/snap.multipass.multipassd.service.d/override.conf"
                 _run sudo mkdir -p $( dirname ${OVERRIDE_CONF} )
@@ -216,11 +217,18 @@ jobs:
                   [Service]
                   ExecStart=
                   ExecStart=/usr/bin/snap run multipass.multipassd --verbosity trace
+                  Environment=MULTIPASS_BLUEPRINTS_URL=${MULTIPASS_BLUEPRINTS_URL}
               EOF
                 _install beta
 
               elif [ '${{ matrix.os }}' == 'macOS' ]; then
+                PLIST_FILE="/Library/LaunchDaemons/com.canonical.multipassd.plist"
                 _install https://github.com/canonical/multipass/releases/download/v1.9.0-rc/multipass-1.9.0-rc.557+gc2561306.mac-Darwin.pkg
+                _run "sudo /usr/libexec/PlistBuddy -c \
+                  'Add :EnvironmentVariables:MULTIPASS_BLUEPRINTS_URL string ${MULTIPASS_BLUEPRINTS_URL}' \
+                  ${PLIST_FILE}"
+                _run sudo launchctl unload "${PLIST_FILE}"
+                _run sudo launchctl load "${PLIST_FILE}"
               fi
 
               # Give multipassd time to settle (canonical/multipass#1995)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ instances:
     cloud-init:
       vendor-data: |       # cloud-init vendor data
         <string>
+
+health-check: |            # a health-check shell script ran by integration tests
+  <string>
 ```
 
 ## Testing

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -109,3 +109,14 @@ instances:
           sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome
 
         final_message: "The system is finally up, after $UPTIME seconds"
+
+health-check: |
+  set -e
+
+  charmcraft version
+
+  mkdir hello-world
+  cd hello-world
+
+  charmcraft init
+  charmcraft pack

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -134,3 +134,6 @@ instances:
           apt-get autoremove -y
 
         final_message: "The system is finally up, after $UPTIME seconds"
+
+health-check: |
+  docker run hello-world

--- a/v1/minikube.yaml
+++ b/v1/minikube.yaml
@@ -101,3 +101,9 @@ instances:
         - wget https://storage.googleapis.com/minikube/releases/latest/minikube_latest_$( dpkg-architecture -q DEB_HOST_ARCH ).deb
         - apt-get install --yes --no-install-recommends -o Debug::pkgProblemResolver=yes ./minikube_latest_$( dpkg-architecture -q DEB_HOST_ARCH ).deb
         - sudo -u ubuntu minikube start --driver=docker
+
+health-check: |
+  set -e
+
+  minikube status
+  kubectl cluster-info

--- a/v1/minikube.yaml
+++ b/v1/minikube.yaml
@@ -14,7 +14,7 @@ instances:
       min-cpu: 2
       min-mem: 4G
       min-disk: 40G
-    timeout: 900
+    timeout: 1800
     cloud-init:
       vendor-data: |
         apt:


### PR DESCRIPTION
1. Adds a top-level `health-check` script to be executed on the main instance as a health check.
2. On pull requests, test the modified blueprints across a set of drivers
3. Add a manual trigger for testing a particular blueprint