### PR TITLE
[docker] upgrade to portainer-ce

### DIFF
--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -129,7 +129,7 @@ instances:
             --restart=always \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v portainer_data:/data \
-            portainer/portainer
+            portainer/portainer-ce
 
         - |
           # apt cleanup


### PR DESCRIPTION
Version 1.24.x is deprecated:
https://hub.docker.com/r/portainer/portainer

Use version 2.x, aka Portainer Community Edition, image instead.