### PR TITLE
[charm-dev] Write kube config file as regular user

### DIFF
--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -37,6 +37,7 @@ instances:
         - fzf
         - tox
         - gnome-keyring
+        - kitty-terminfo
 
         snap:
           commands:

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -3,6 +3,10 @@
 # so you can `juju deploy` right away.
 # For development convenience, charmcraft and tox are installed as well.
 # If you are a zsh user, the ohmyzsh juju plugin is already enabled when you switch to zsh.
+#
+# To create a VM similar to a GitHub-hosted runner:
+# multipass launch --mem 7G --cpus 2 --name charm-dev-2cpu-7g charm-dev
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 
 
 description: A development and testing environment for charmers

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -100,13 +100,6 @@ instances:
           microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
           microk8s.kubectl rollout status daemonsets/nginx-ingress-microk8s-controller -n ingress -w --timeout=600s
 
-          # workaround for
-          # ERROR resolving microk8s credentials: max duration exceeded: secret for service account "juju-credential-microk8s" not found
-          # Ref: https://github.com/charmed-kubernetes/actions-operator/blob/main/src/bootstrap/index.ts
-          microk8s kubectl create serviceaccount test-sa
-          timeout 600 sh -c "until microk8s kubectl get secrets | grep -q test-sa-token-; do sleep 5; done"
-          microk8s kubectl delete serviceaccount test-sa
-
           sudo -u ubuntu juju bootstrap --no-gui microk8s charm-dev
           sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome
 

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -15,7 +15,7 @@ runs-on:
 
 instances:
   charm-dev:
-    image: 20.04
+    image: 22.04
     limits:
       min-cpu: 2
       min-mem: 4G

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -39,6 +39,7 @@ instances:
           - snap install --classic juju
           - snap install --classic microk8s
           - snap alias microk8s.kubectl kubectl
+          - snap alias microk8s.kubectl k
           - snap install --classic charmcraft
           - snap install yq
           - snap refresh
@@ -111,6 +112,6 @@ instances:
 
           # dump config (this is needed for utils such as k9s or kdash)
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube
-          microk8s config > /home/ubuntu/.kube/config
+          microk8s config | sudo -u ubuntu tee /home/ubuntu/.kube/config > /dev/null
 
         final_message: "The system is finally up, after $UPTIME seconds"

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -93,6 +93,9 @@ instances:
           adduser ubuntu microk8s
           microk8s status --wait-ready
           
+          microk8s.enable metrics-server
+          microk8s.kubectl rollout status deployments/metrics-server -n kube-system -w --timeout=600s
+
           # The dns addon will restart the api server so you may see a blip in the availability
           # Separating addons to avoid errors such as 
           # dial tcp 127.0.0.1:16443: connect: connection refused

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -24,7 +24,7 @@ instances:
       min-cpu: 2
       min-mem: 4G
       min-disk: 30G
-    timeout: 900
+    timeout: 1200
     cloud-init:
       vendor-data: |
         package_update: true

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -99,7 +99,7 @@ instances:
           microk8s.enable dns
           microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
           
-          microk8s.enable storage
+          microk8s.enable hostpath-storage
           microk8s.enable ingress
           # wait for storage, ingress to become available
           microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s


### PR DESCRIPTION
- Before this change, the `~/.kube/config` file is created and owned by `root`, so not readily available for apps to use.
This PR writes the file as the default user (`ubuntu`).
- Remove the [`test-sa` workaround](https://github.com/charmed-kubernetes/actions-operator/issues/37), now that with uk8s 1.24 causes the cloud-init to hang on `No resources found in default namespace.`
- Drive-by fixes:
  - use the new jammy
  - increase timeout (`launch failed: The following errors occurred: timed out waiting for initialization to complete`)
  - add k as alias to kubectl
  - support more terminals ootb