### PR TITLE
[docker] Use 22.04 release for image

### DIFF
--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -10,7 +10,7 @@ runs-on:
 
 instances:
   docker:
-    image: 21.10
+    image: 22.04
     limits:
       min-cpu: 2
       min-mem: 4G


### PR DESCRIPTION
Fixes canonical/multipass#2662