### PR TITLE
[jellyfin] Fix instance name in yaml

### DIFF
--- a/v1/jellyfin.yaml
+++ b/v1/jellyfin.yaml
@@ -6,7 +6,7 @@ runs-on:
 - x86_64
 
 instances:
-  docker:
+  jellyfin:
     image: 20.04
     limits:
       min-cpu: 2


### PR DESCRIPTION
The instance name must match the Blueprint file name.