### PR TITLE
Add blueprints for ROS Noetic and ROS 2 Humble

### DIFF
--- a/v1/ros-noetic.yaml
+++ b/v1/ros-noetic.yaml
@@ -64,7 +64,7 @@ instances:
           append: true
           defer: true
 
-        run_cmd:
+        runcmd:
         - |
           # Initialise rosdep
           rosdep init

--- a/v1/ros-noetic.yaml
+++ b/v1/ros-noetic.yaml
@@ -1,0 +1,82 @@
+description: A development and testing environment for ROS Noetic.
+version: latest
+
+runs-on:
+- arm64
+- x86_64
+
+instances:
+  ros-noetic:
+    image: 20.04
+    limits:
+      min-cpu: 2
+      min-mem: 4G
+      min-disk: 40G
+    timeout: 1200
+    cloud-init:
+      vendor-data: |
+        apt:
+          sources:
+            ros2:
+              source: "deb http://packages.ros.org/ros/ubuntu $RELEASE main"
+              keyid: C1CF 6E31 E6BA DE88 68B1 72B4 F42E D6FB AB17 C654
+
+        package_upgrade: true
+
+        packages:
+        - build-essential
+        - cmake
+        - curl
+        - git
+        - lsb-release
+        - openssh-client
+        - openssh-server
+        - python3
+        - python3-pip
+        - snapd
+        - tig
+        - unzip
+        - vim
+        - wget
+        - zip
+        # ROS specific packages
+        - python3-catkin-tools
+        - python3-rosdep
+        - python3-rosinstall
+        - python3-rosinstall-generator
+        - python3-vcstool
+        - ros-noetic-desktop-full
+
+        snap:
+          commands:
+          - snap install snapcraft --classic
+
+        write_files:
+
+        - content: |
+
+            [[ -z "${XAUTHORITY}" ]] && export XAUTHORITY=$HOME/.Xauthority
+
+            if [ -f /opt/ros/noetic/setup.bash ]; then
+              source /opt/ros/noetic/setup.bash
+            fi
+          path: /home/ubuntu/.bashrc
+          append: true
+          defer: true
+
+        run_cmd:
+        - |
+          # Initialise rosdep
+          rosdep init
+          sudo -u ubuntu sh -c "rosdep update --rosdistro noetic"
+
+        final_message: "The ROS Noetic environment is up, after $UPTIME seconds."
+
+health-check: |
+  set -e
+
+  rosdep --version
+  ls /etc/ros/rosdep/sources.list.d/20-default.list
+  ls /home/ubuntu/.ros/rosdep/sources.cache
+
+  ls /opt/ros/noetic

--- a/v1/ros-noetic.yaml
+++ b/v1/ros-noetic.yaml
@@ -12,7 +12,7 @@ instances:
       min-cpu: 2
       min-mem: 4G
       min-disk: 40G
-    timeout: 1200
+    timeout: 1800
     cloud-init:
       vendor-data: |
         apt:

--- a/v1/ros-noetic.yaml
+++ b/v1/ros-noetic.yaml
@@ -1,5 +1,5 @@
 description: A development and testing environment for ROS Noetic.
-version: latest
+version: 0.1
 
 runs-on:
 - arm64

--- a/v1/ros2-humble.yaml
+++ b/v1/ros2-humble.yaml
@@ -69,7 +69,7 @@ instances:
           append: true
           defer: true
 
-        run_cmd:
+        runcmd:
         - |
           # Initialise rosdep
           rosdep init

--- a/v1/ros2-humble.yaml
+++ b/v1/ros2-humble.yaml
@@ -1,5 +1,5 @@
 description: A development and testing environment for ROS 2 Humble.
-version: latest
+version: 0.1
 
 runs-on:
 - arm64

--- a/v1/ros2-humble.yaml
+++ b/v1/ros2-humble.yaml
@@ -12,7 +12,7 @@ instances:
       min-cpu: 2
       min-mem: 4G
       min-disk: 40G
-    timeout: 1200
+    timeout: 1800
     cloud-init:
       vendor-data: |
         apt:

--- a/v1/ros2-humble.yaml
+++ b/v1/ros2-humble.yaml
@@ -1,0 +1,88 @@
+description: A development and testing environment for ROS 2 Humble.
+version: latest
+
+runs-on:
+- arm64
+- x86_64
+
+instances:
+  ros2-humble:
+    image: 22.04
+    limits:
+      min-cpu: 2
+      min-mem: 4G
+      min-disk: 40G
+    timeout: 1200
+    cloud-init:
+      vendor-data: |
+        apt:
+          sources:
+            ros2:
+              source: "deb http://repo.ros2.org/ubuntu/main $RELEASE main"
+              keyid: C1CF 6E31 E6BA DE88 68B1 72B4 F42E D6FB AB17 C654
+
+        package_upgrade: true
+
+        packages:
+        - build-essential
+        - cmake
+        - curl
+        - git
+        - lsb-release
+        - openssh-client
+        - openssh-server
+        - python3
+        - python3-pip
+        - snapd
+        - tig
+        - unzip
+        - vim
+        - wget
+        - zip
+        # ROS 2 specific packages
+        - python3-colcon-common-extensions
+        - python3-rosdep
+        - python3-setuptools
+        - python3-vcstool
+        - ros-humble-desktop-full
+
+        snap:
+          commands:
+          - snap install snapcraft --classic
+
+        write_files:
+
+        - content: |
+
+            [[ -z "${COLCON_HOME}" ]] && export COLCON_HOME="$HOME/.colcon"
+
+            [[ -z "${XAUTHORITY}" ]] && export XAUTHORITY=$HOME/.Xauthority
+
+            if [ -f /opt/ros/humble/setup.bash ]; then
+              source /opt/ros/humble/setup.bash
+            fi
+
+            if [ -f /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash ]; then
+              source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash
+            fi
+          path: /home/ubuntu/.bashrc
+          append: true
+          defer: true
+
+        run_cmd:
+        - |
+          # Initialise rosdep
+          rosdep init
+          sudo -u ubuntu sh -c "rosdep update --rosdistro humble"
+
+        final_message: "The ROS 2 Humble environment is up, after $UPTIME seconds."
+
+health-check: |
+  set -e
+
+  colcon --help
+  rosdep --version
+  ls /etc/ros/rosdep/sources.list.d/20-default.list
+  ls /home/ubuntu/.ros/rosdep/sources.cache
+
+  ls /opt/ros/humble


### PR DESCRIPTION
This PR adds blueprints for both [ROS Noetic](http://wiki.ros.org/noetic) and [ROS 2 Humble](https://docs.ros.org/en/humble/index.html) which are the latest LTS releases of the [Robot Operating System (ROS)](https://www.ros.org/) 1 & 2.  
They both enable the upstream repo, install the project and set up the environment for the user to be ready to develop.