### PR TITLE
Use https for ubuntu cloud images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multipass Blueprints
 This repository contains Multipass Blueprint definitions. They augment the offerings already available from the
-[Ubuntu Cloud Images](http://cloud-images.ubuntu.com/). You can list the available images with
+[Ubuntu Cloud Images](https://cloud-images.ubuntu.com/). You can list the available images with
 [`multipass find`](https://multipass.run/docs/find-command) and run them with [`multipass launch`](https://multipass.run/docs/launch-command):
 
 ```plain


### PR DESCRIPTION
Use https as cloud images hyperlink in readme redirects to http page

Not sure why reverse proxy(if there's any?) serving the site is not doing a permanent redirect for http to https