### PR TITLE
Update charm-dev to juju 3.1

### DIFF
--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -126,7 +126,7 @@ instances:
           # MetalLB
           IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
           microk8s enable metallb:$IPADDR-$IPADDR
-	  microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
+    microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
 
           # dump config (this is needed for utils such as k9s or kdash)
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -126,7 +126,7 @@ instances:
           # MetalLB
           IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
           microk8s enable metallb:$IPADDR-$IPADDR
-    microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
+          microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
 
           # dump config (this is needed for utils such as k9s or kdash)
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -105,7 +105,6 @@ instances:
         - |
           # setup microk8s and bootstrap
           usermod -a -G snap_microk8s ubuntu
-          usermod -a -G microk8s ubuntu
           microk8s status --wait-ready
 
           microk8s.enable metrics-server

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -41,7 +41,8 @@ instances:
 
         snap:
           commands:
-          - snap install juju --channel=3.2/stable
+          # Juju 3.1 is supported until 25.04
+          - snap install juju --channel=3.1/stable
           - snap install microk8s --channel=1.27-strict/stable
           - snap alias microk8s.kubectl kubectl
           - snap alias microk8s.kubectl k
@@ -125,9 +126,6 @@ instances:
           IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
           microk8s enable metallb:$IPADDR-$IPADDR
           microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
-
-          # For some reason, without this sleep, bootstrapping a controller errors out with "Terminated".
-          sleep 30
 
           # bootstrap controllers
           sudo -u ubuntu juju bootstrap localhost lxd

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -5,7 +5,7 @@
 # If you are a zsh user, the ohmyzsh juju plugin is already enabled when you switch to zsh.
 #
 # To create a VM similar to a GitHub-hosted runner:
-# multipass launch --mem 7G --cpus 2 --name charm-dev-2cpu-7g charm-dev
+# multipass launch --memory 7G --cpus 2 --name charm-dev-2cpu-7g charm-dev
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 
 
@@ -41,16 +41,19 @@ instances:
 
         snap:
           commands:
-          - snap install --classic juju
-          - snap install --classic microk8s
+          - snap install juju --channel=3.2/stable
+          - snap install microk8s --channel=1.27-strict/stable
           - snap alias microk8s.kubectl kubectl
           - snap alias microk8s.kubectl k
           - snap install --classic charmcraft
+          - snap install jhack --channel=latest/stable
           - snap install yq
           - snap refresh
 
         runcmd:
-        - DEBIAN_FRONTEND=noninteractive apt -y upgrade
+        - DEBIAN_FRONTEND=noninteractive apt-get remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme
+        - DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+        - DEBIAN_FRONTEND=noninteractive apt-get -y autoremove
 
         - |
           # disable swap
@@ -71,6 +74,12 @@ instances:
           systemctl disable ua-timer.timer ua-timer.service --now
           systemctl disable systemd-tmpfiles-clean.timer --now
 
+          # Disable IPv6
+          echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
+          echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
+          echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
+          sysctl -p
+
         - |
           # apt cleanup
           apt remove -y landscape-client landscape-common
@@ -89,31 +98,47 @@ instances:
           adduser ubuntu lxd
 
         - |
+          # Make sure juju directory is there
+          # https://bugs.launchpad.net/juju/+bug/1995697
+          sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
+
+          # Manually copy credentials to /var/snap/juju/current/microk8s/credentials/client.config
+          mkdir -p /var/snap/juju/current/microk8s/credentials
+          microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
+
+        - |
           # setup microk8s and bootstrap
-          adduser ubuntu microk8s
+          usermod -a -G snap_microk8s ubuntu
+          usermod -a -G microk8s ubuntu
           microk8s status --wait-ready
-          
+
           microk8s.enable metrics-server
           microk8s.kubectl rollout status deployments/metrics-server -n kube-system -w --timeout=600s
 
           # The dns addon will restart the api server so you may see a blip in the availability
-          # Separating addons to avoid errors such as 
+          # Separating addons to avoid errors such as
           # dial tcp 127.0.0.1:16443: connect: connection refused
           microk8s.enable dns
           microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
-          
+
+          # wait for storage, ingress to become available
           microk8s.enable hostpath-storage
           microk8s.enable ingress
-          # wait for storage, ingress to become available
           microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
           microk8s.kubectl rollout status daemonsets/nginx-ingress-microk8s-controller -n ingress -w --timeout=600s
-
-          sudo -u ubuntu juju bootstrap --no-gui microk8s charm-dev
-          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome
 
           # dump config (this is needed for utils such as k9s or kdash)
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube
           microk8s config | sudo -u ubuntu tee /home/ubuntu/.kube/config > /dev/null
+
+          # bootstrap controllers
+          sudo -u ubuntu juju bootstrap microk8s microk8s
+          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
+          sudo -u ubuntu juju bootstrap localhost lxd
+          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-lxd
+
+          # We need to connect the dot-local-share-juju interface with jhack
+          sudo snap connect jhack:dot-local-share-juju snapd
 
         final_message: "The system is finally up, after $UPTIME seconds"
 

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -52,9 +52,9 @@ instances:
           - snap refresh
 
         runcmd:
-        - DEBIAN_FRONTEND=noninteractive apt-get remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme
-        - DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-        - DEBIAN_FRONTEND=noninteractive apt-get -y autoremove
+        - DEBIAN_FRONTEND=noninteractive apt remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme
+        - DEBIAN_FRONTEND=noninteractive apt -y upgrade
+        - DEBIAN_FRONTEND=noninteractive apt -y autoremove
 
         - |
           # disable swap
@@ -84,7 +84,7 @@ instances:
         - |
           # apt cleanup
           apt remove -y landscape-client landscape-common
-          apt-get autoremove -y
+          apt autoremove -y
 
         - |
           # oh-my-zsh + juju plugin

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -82,11 +82,6 @@ instances:
           sysctl -p
 
         - |
-          # apt cleanup
-          apt remove -y landscape-client landscape-common
-          apt autoremove -y
-
-        - |
           # oh-my-zsh + juju plugin
           sudo -u ubuntu sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
           sudo -u ubuntu git clone https://github.com/zsh-users/zsh-autosuggestions.git ~ubuntu/.oh-my-zsh/custom/plugins/zsh-autosuggestions

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -119,18 +119,12 @@ instances:
 
           # wait for storage become available
           microk8s.enable hostpath-storage
-          #microk8s.enable ingress
           microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
-          #microk8s.kubectl rollout status daemonsets/nginx-ingress-microk8s-controller -n ingress -w --timeout=600s
 
           # MetalLB
           IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
           microk8s enable metallb:$IPADDR-$IPADDR
           microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
-
-          ## Manually copy credentials to /var/snap/juju/current/microk8s/credentials/client.config
-          #mkdir -p /var/snap/juju/current/microk8s/credentials
-          #microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
 
           # For some reason, without this sleep, bootstrapping a controller errors out with "Terminated".
           sleep 30

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -102,10 +102,6 @@ instances:
           # https://bugs.launchpad.net/juju/+bug/1995697
           sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
 
-          # Manually copy credentials to /var/snap/juju/current/microk8s/credentials/client.config
-          mkdir -p /var/snap/juju/current/microk8s/credentials
-          microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
-
         - |
           # setup microk8s and bootstrap
           usermod -a -G snap_microk8s ubuntu
@@ -131,11 +127,15 @@ instances:
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube
           microk8s config | sudo -u ubuntu tee /home/ubuntu/.kube/config > /dev/null
 
+          # Manually copy credentials to /var/snap/juju/current/microk8s/credentials/client.config
+          mkdir -p /var/snap/juju/current/microk8s/credentials
+          microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
+
           # bootstrap controllers
-          sudo -u ubuntu juju bootstrap microk8s microk8s
-          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
           sudo -u ubuntu juju bootstrap localhost lxd
           sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-lxd
+          sudo -u ubuntu juju bootstrap microk8s microk8s
+          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
 
           # We need to connect the dot-local-share-juju interface with jhack
           sudo snap connect jhack:dot-local-share-juju snapd

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -105,6 +105,7 @@ instances:
         - |
           # setup microk8s and bootstrap
           usermod -a -G snap_microk8s ubuntu
+          usermod -a -G microk8s ubuntu
           microk8s status --wait-ready
 
           microk8s.enable metrics-server
@@ -116,11 +117,16 @@ instances:
           microk8s.enable dns
           microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
 
-          # wait for storage, ingress to become available
+          # wait for storage become available
           microk8s.enable hostpath-storage
-          microk8s.enable ingress
+          #microk8s.enable ingress
           microk8s.kubectl rollout status deployments/hostpath-provisioner -n kube-system -w --timeout=600s
-          microk8s.kubectl rollout status daemonsets/nginx-ingress-microk8s-controller -n ingress -w --timeout=600s
+          #microk8s.kubectl rollout status daemonsets/nginx-ingress-microk8s-controller -n ingress -w --timeout=600s
+
+          # MetalLB
+          IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+          microk8s enable metallb:$IPADDR-$IPADDR
+	  microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
 
           # dump config (this is needed for utils such as k9s or kdash)
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube
@@ -131,10 +137,10 @@ instances:
           microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
 
           # bootstrap controllers
-          sudo -u ubuntu juju bootstrap localhost lxd
-          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-lxd
           sudo -u ubuntu juju bootstrap microk8s microk8s
           sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
+          sudo -u ubuntu juju bootstrap localhost lxd
+          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-lxd
 
           # We need to connect the dot-local-share-juju interface with jhack
           sudo snap connect jhack:dot-local-share-juju snapd

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -114,7 +114,7 @@ instances:
           # The dns addon will restart the api server so you may see a blip in the availability
           # Separating addons to avoid errors such as
           # dial tcp 127.0.0.1:16443: connect: connection refused
-          microk8s.enable dns
+          microk8s.enable dns rbac
           microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
 
           # wait for storage become available
@@ -128,19 +128,22 @@ instances:
           microk8s enable metallb:$IPADDR-$IPADDR
           microk8s.kubectl rollout status daemonset.apps/speaker -n metallb-system -w --timeout=600s
 
+          ## Manually copy credentials to /var/snap/juju/current/microk8s/credentials/client.config
+          #mkdir -p /var/snap/juju/current/microk8s/credentials
+          #microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
+
+          # For some reason, without this sleep, bootstrapping a controller errors out with "Terminated".
+          sleep 30
+
+          # bootstrap controllers
+          sudo -u ubuntu juju bootstrap localhost lxd
+          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-lxd
+          sudo -u ubuntu juju bootstrap microk8s microk8s
+          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
+
           # dump config (this is needed for utils such as k9s or kdash)
           sudo -u ubuntu mkdir -p /home/ubuntu/.kube
           microk8s config | sudo -u ubuntu tee /home/ubuntu/.kube/config > /dev/null
-
-          # Manually copy credentials to /var/snap/juju/current/microk8s/credentials/client.config
-          mkdir -p /var/snap/juju/current/microk8s/credentials
-          microk8s config | tee /var/snap/juju/current/microk8s/credentials/client.config > /dev/null
-
-          # bootstrap controllers
-          sudo -u ubuntu juju bootstrap microk8s microk8s
-          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-k8s
-          sudo -u ubuntu juju bootstrap localhost lxd
-          sudo -u ubuntu juju add-model --config logging-config="<root>=WARNING; unit=DEBUG" --config update-status-hook-interval="60m" welcome-lxd
 
           # We need to connect the dot-local-share-juju interface with jhack
           sudo snap connect jhack:dot-local-share-juju snapd


### PR DESCRIPTION
The juju snap now has version 3.1 as `stable` so it might be a good time to update the `charm-dev` blueprint.

- Introduce explicit version pin to reduce brittleness of the blueprint: juju 3.1/stable and microk8s 1.27-strict/stable.
- Pick up some goodies from @Abuelodelanada's [cloud-init](https://github.com/Abuelodelanada/charm-dev-utils/blob/main/cloud-init/charm-dev-juju-3.1.yaml).
- Pick up the credentials fix from #33 