### PR TITLE
Install tox from pypi

### DIFF
--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -7,7 +7,11 @@
 # To create a VM similar to a GitHub-hosted runner:
 # multipass launch --memory 7G --cpus 2 --name charm-dev-2cpu-7g charm-dev
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-
+#
+# To only test the cloud init portion of this blueprint:
+#
+#   yq '.instances."charm-dev"."cloud-init"."vendor-data"' v1/charm-dev.yaml > charm-dev-cloud-init.yaml
+#   multipass launch --cloud-init ./charm-dev-cloud-init.yaml --name test --memory 7G --cpus 2 --disk 30G
 
 description: A development and testing environment for charmers
 version: latest
@@ -28,6 +32,8 @@ instances:
     cloud-init:
       vendor-data: |
         package_update: true
+        package_upgrade: true
+        package_reboot_if_required: true
 
         packages:
         - python3-pip
@@ -35,7 +41,8 @@ instances:
         - sysstat
         - zsh
         - fzf
-        - tox
+        - bat
+        - ripgrep
         - gnome-keyring
         - kitty-terminfo
 
@@ -43,7 +50,7 @@ instances:
           commands:
           # Juju 3.1 is supported until 25.04
           - snap install juju --channel=3.1/stable
-          - snap install microk8s --channel=1.27-strict/stable
+          - snap install microk8s --channel=1.28-strict/stable
           - snap alias microk8s.kubectl kubectl
           - snap alias microk8s.kubectl k
           - snap install --classic charmcraft
@@ -56,6 +63,10 @@ instances:
         - DEBIAN_FRONTEND=noninteractive apt -y upgrade
         - DEBIAN_FRONTEND=noninteractive apt -y autoremove
 
+        - |
+          # Install tox from pypi (v4) instead of apt (v3)
+          sudo -u ubuntu pip install tox
+          
         - |
           # disable swap
           sysctl -w vm.swappiness=0
@@ -110,8 +121,10 @@ instances:
           # The dns addon will restart the api server so you may see a blip in the availability
           # Separating addons to avoid errors such as
           # dial tcp 127.0.0.1:16443: connect: connection refused
-          microk8s.enable dns rbac
+          microk8s.enable dns
           microk8s.kubectl rollout status deployments/coredns -n kube-system -w --timeout=600s
+
+          microk8s.enable rbac
 
           # wait for storage become available
           microk8s.enable hostpath-storage
@@ -134,6 +147,7 @@ instances:
 
           # We need to connect the dot-local-share-juju interface with jhack
           sudo snap connect jhack:dot-local-share-juju snapd
+          sudo snap connect jhack:ssh-read snapd        
 
         final_message: "The system is finally up, after $UPTIME seconds"
 


### PR DESCRIPTION
In this PR:
- Tox from apt is quite dated. Install from PyPI instead. Fixes #43.
- Bump microk8s to 1.28. There is no strictly confined 1.29 at this point.
- Install bat, rg. These seem to have gained popularity.
- Update jhack installation.

