### PR TITLE
Add ros2-jazzy

### DIFF
--- a/v1/ros2-jazzy.yaml
+++ b/v1/ros2-jazzy.yaml
@@ -18,9 +18,7 @@ instances:
         apt:
           sources:
             ros2:
-              source: "deb http://packages.ros.org/ros2-testing/ubuntu $RELEASE main"
-              # Use this once released
-              # source: "deb http://packages.ros.org/ros2/ubuntu $RELEASE main"
+              source: "deb http://packages.ros.org/ros2/ubuntu $RELEASE main"
               keyid: C1CF 6E31 E6BA DE88 68B1 72B4 F42E D6FB AB17 C654
 
         package_upgrade: true

--- a/v1/ros2-jazzy.yaml
+++ b/v1/ros2-jazzy.yaml
@@ -1,0 +1,90 @@
+description: A development and testing environment for ROS 2 Jazzy.
+version: 0.1
+
+runs-on:
+- arm64
+- x86_64
+
+instances:
+  ros2-jazzy:
+    image: 24.04
+    limits:
+      min-cpu: 2
+      min-mem: 4G
+      min-disk: 40G
+    timeout: 1800
+    cloud-init:
+      vendor-data: |
+        apt:
+          sources:
+            ros2:
+              source: "deb http://packages.ros.org/ros2-testing/ubuntu $RELEASE main"
+              # Use this once released
+              # source: "deb http://packages.ros.org/ros2/ubuntu $RELEASE main"
+              keyid: C1CF 6E31 E6BA DE88 68B1 72B4 F42E D6FB AB17 C654
+
+        package_upgrade: true
+
+        packages:
+        - build-essential
+        - cmake
+        - curl
+        - git
+        - lsb-release
+        - openssh-client
+        - openssh-server
+        - python3
+        - python3-pip
+        - snapd
+        - tig
+        - unzip
+        - vim
+        - wget
+        - zip
+        # ROS 2 specific packages
+        - python3-colcon-common-extensions
+        - python3-rosdep
+        - python3-setuptools
+        - python3-vcstool
+        - ros-jazzy-desktop-full
+
+        snap:
+          commands:
+          - snap install snapcraft --classic
+
+        write_files:
+
+        - content: |
+
+            [[ -z "${COLCON_HOME}" ]] && export COLCON_HOME="$HOME/.colcon"
+
+            [[ -z "${XAUTHORITY}" ]] && export XAUTHORITY=$HOME/.Xauthority
+
+            if [ -f /opt/ros/jazzy/setup.bash ]; then
+              source /opt/ros/jazzy/setup.bash
+            fi
+
+            if [ -f /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash ]; then
+              source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash
+            fi
+          path: /home/ubuntu/.bashrc
+          append: true
+          defer: true
+
+        runcmd:
+        - |
+          # Initialise rosdep
+          rosdep init
+          sudo -u ubuntu sh -c "rosdep update --rosdistro jazzy"
+
+        final_message: "The ROS 2 Jazzy environment is up, after $UPTIME seconds."
+
+health-check: |
+  set -e
+
+  colcon --help
+  rosdep --version
+  ls /etc/ros/rosdep/sources.list.d/20-default.list
+  ls /home/ubuntu/.ros/rosdep/sources.cache
+
+  ls /opt/ros/jazzy


### PR DESCRIPTION
This PR adds a blueprint to setup a ROS 2 Jazzy environment (which is based on 24.04).

It is analogous to https://github.com/canonical/multipass-blueprints/pull/29.