### PR TITLE
Revert docker blueprint

### DIFF
--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -1,5 +1,5 @@
 description: A Docker environment with Portainer and related tools
-version: 0.5
+version: 0.4
 
 runs-on:
 - arm

--- a/v1/docker.yaml
+++ b/v1/docker.yaml
@@ -14,7 +14,7 @@ aliases:
 
 instances:
   docker:
-    image: 24.04
+    image: 22.04
     workspace: true
     limits:
       min-cpu: 2


### PR DESCRIPTION
Revert docker blueprint to version 0.4, on 22.04.

Fixes #53 