### PR TITLE
[charm-dev] bump versions

### DIFF
--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -11,7 +11,7 @@
 # To only test the cloud init portion of this blueprint:
 #
 #   yq '.instances."charm-dev"."cloud-init"."vendor-data"' v1/charm-dev.yaml > charm-dev-cloud-init.yaml
-#   multipass launch --cloud-init ./charm-dev-cloud-init.yaml --name test --memory 7G --cpus 2 --disk 30G
+#   multipass launch noble --cloud-init ./charm-dev-cloud-init.yaml --name test --memory 16G --cpus 8 --disk 100G
 
 description: A development and testing environment for charmers
 version: latest
@@ -23,7 +23,7 @@ runs-on:
 
 instances:
   charm-dev:
-    image: 22.04
+    image: 24.04
     limits:
       min-cpu: 2
       min-mem: 4G
@@ -48,10 +48,10 @@ instances:
 
         snap:
           commands:
-          # Juju 3.5 is supported until Jan 2025
+          # Juju 3.6 is an LTS. Install beta to help the juju team with testing.
           # https://juju.is/docs/juju/roadmap
-          - snap install juju --channel=3.5/stable
-          - snap install microk8s --channel=1.29-strict/stable
+          - snap install juju --channel=3.6/beta
+          - snap install microk8s --channel=1.30-strict/stable
           - snap alias microk8s.kubectl kubectl
           - snap alias microk8s.kubectl k
           - snap install --classic charmcraft

--- a/v1/charm-dev.yaml
+++ b/v1/charm-dev.yaml
@@ -48,9 +48,9 @@ instances:
 
         snap:
           commands:
-          # Juju 3.6 is an LTS. Install beta to help the juju team with testing.
+          # Juju 3.6 is an LTS.
           # https://juju.is/docs/juju/roadmap
-          - snap install juju --channel=3.6/beta
+          - snap install juju --channel=3.5/stable
           - snap install microk8s --channel=1.30-strict/stable
           - snap alias microk8s.kubectl kubectl
           - snap alias microk8s.kubectl k
@@ -59,6 +59,21 @@ instances:
           - snap install jhack --channel=latest/stable
           - snap install yq
           - snap refresh
+
+        write_files:
+        - path: "/etc/update-motd.d/99-use-beta-channels"
+          permissions: "0755"
+          content: |
+            #!/bin/sh
+
+            echo "======================================================================"
+            echo " If you're feeling adventurous, you could help the charming community"
+            echo " by switching to the beta channels and reporting any issues you "
+            echo " encounter in you journey!"
+            echo
+            echo "   sudo snap refresh juju --channel=3/beta"
+            echo "   sudo snap refresh charmcraft --classic --channel=3.x/beta"
+            echo "======================================================================"
 
         runcmd:
         - DEBIAN_FRONTEND=noninteractive apt remove -y landscape-client landscape-common adwaita-icon-theme humanity-icon-theme


### PR DESCRIPTION
In this PR, bumping:
- ubuntu from 22.04 to 24.04
- MicroK8s 1.29 to 1.30
- Add a motd message encouraging users to use beta channels to help the charming community.