### PR TITLE
Change MacOS integration to use latest multipass version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -225,7 +225,7 @@ jobs:
 
               elif [ '${{ matrix.os }}' == 'macOS' ]; then
                 PLIST_FILE="/Library/LaunchDaemons/com.canonical.multipassd.plist"
-                _install https://github.com/canonical/multipass/releases/download/v1.9.0-rc/multipass-1.9.0-rc.557+gc2561306.mac-Darwin.pkg
+                _install https://multipass.run/download/macos
 
                 # force use of the qemu driver
                 _retry 5 30 _run $MP set local.driver=qemu


### PR DESCRIPTION
Previously MacOS would always install Multipass v1.9.0-rc, this deviates from the behavior of Linux tests which install the latest snap from the beta channel. This change makes it so MacOS will fetch the version distributed on [multipass.run](https://multipass.run/install) which is the latest, non-prerelease, version.

MULTI-1402